### PR TITLE
公開APIを追加

### DIFF
--- a/src/main/java/nablarch/core/transaction/TransactionFactory.java
+++ b/src/main/java/nablarch/core/transaction/TransactionFactory.java
@@ -1,10 +1,13 @@
 package nablarch.core.transaction;
 
+import nablarch.core.util.annotation.Published;
+
 /**
  * トランザクション制御オブジェクト({@link Transaction})を生成するインタフェース。。
  *
  * @author Hisaaki Sioiri
  */
+@Published(tag = "architect")
 public interface TransactionFactory {
 
     /**


### PR DESCRIPTION
[解説書](https://nablarch.github.io/docs/LATEST/doc/application_framework/application_framework/libraries/transaction.html#transaction-addresource)には`TransactionFactory`の実装例が記載されているにもかかわらず、公開APIとなっていなかったため、アーキテクト向けの公開APIとしました。